### PR TITLE
Refreshes the _lastReceivedMsg on reconnection

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -415,7 +415,8 @@ namespace Websocket.Client
                 _reconnectionSubject.OnNext(type);
 #pragma warning disable 4014
                 Listen(_client, token);
-#pragma warning restore 4014               
+#pragma warning restore 4014
+                _lastReceivedMsg = DateTime.UtcNow;
                 ActivateLastChance();
             }
             catch (Exception e)


### PR DESCRIPTION
The _lastReceivedMsg value was not being updated after a reconnection. This was causing it to disconnect if no message was sent during the first 5 seconds of connection.