### PR TITLE
Replaced LibLog with Ms Extension logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: csharp
-dotnet: 2.1.803
+dotnet: 3.1.201
 os: linux
 dist: bionic
 mono: latest

--- a/src/Websocket.Client/Websocket.Client.csproj
+++ b/src/Websocket.Client/Websocket.Client.csproj
@@ -29,16 +29,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibLog" Version="5.0.8">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.2" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath=""/>
+    <None Include="icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Websocket.Client/WebsocketClient.Reconnecting.cs
+++ b/src/Websocket.Client/WebsocketClient.Reconnecting.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Websocket.Client.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Websocket.Client
 {
@@ -32,7 +32,7 @@ namespace Websocket.Client
         {
             if (!IsStarted)
             {
-                Logger.Debug(L("Client not started, ignoring reconnection.."));
+                _logger.LogDebug(L("Client not started, ignoring reconnection.."));
                 return;
             }
 
@@ -70,7 +70,7 @@ namespace Websocket.Client
                 if (disInfo.CancelReconnection)
                 {
                     // reconnection canceled by user, do nothing
-                    Logger.Info(L($"Reconnecting canceled by user, exiting."));
+                    _logger.LogInformation(L($"Reconnecting canceled by user, exiting."));
                 }
             }
                 
@@ -86,7 +86,7 @@ namespace Websocket.Client
                 return;
             }
 
-            Logger.Debug(L("Reconnecting..."));
+            _logger.LogDebug(L("Reconnecting..."));
             _cancellation = new CancellationTokenSource();
             await StartClient(_url, _cancellation.Token, type, failFast).ConfigureAwait(false);
             _reconnecting = false;
@@ -117,7 +117,7 @@ namespace Websocket.Client
             var diffMs = Math.Abs(DateTime.UtcNow.Subtract(_lastReceivedMsg).TotalMilliseconds);
             if (diffMs > timeoutMs)
             {
-                Logger.Debug(L($"Last message received more than {timeoutMs:F} ms ago. Hard restart.."));
+                _logger.LogDebug(L($"Last message received more than {timeoutMs:F} ms ago. Hard restart.."));
 
                 DeactivateLastChance();
                 _ = ReconnectSynchronized(ReconnectionType.NoMessageReceived, false, null);

--- a/src/Websocket.Client/WebsocketClient.Sending.cs
+++ b/src/Websocket.Client/WebsocketClient.Sending.cs
@@ -2,7 +2,7 @@
 using System.Net.WebSockets;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Websocket.Client.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace Websocket.Client
 {
@@ -97,7 +97,7 @@ namespace Websocket.Client
                         }
                         catch (Exception e)
                         {
-                            Logger.Error(L($"Failed to send text message: '{message}'. Error: {e.Message}"));
+                            _logger.LogError(L($"Failed to send text message: '{message}'. Error: {e.Message}"));
                         }
                     }
                 }
@@ -118,7 +118,7 @@ namespace Websocket.Client
                     return;
                 }
 
-                Logger.Trace(L($"Sending text thread failed, error: {e.Message}. Creating a new sending thread."));
+                _logger.LogTrace(L($"Sending text thread failed, error: {e.Message}. Creating a new sending thread."));
                 StartBackgroundThreadForSendingText();
             }
 
@@ -138,7 +138,7 @@ namespace Websocket.Client
                         }
                         catch (Exception e)
                         {
-                            Logger.Error(L($"Failed to send binary message: '{message}'. Error: {e.Message}"));
+                            _logger.LogError(L($"Failed to send binary message: '{message}'. Error: {e.Message}"));
                         }
                     }
                 }
@@ -159,7 +159,7 @@ namespace Websocket.Client
                     return;
                 }
 
-                Logger.Trace(L($"Sending binary thread failed, error: {e.Message}. Creating a new sending thread."));
+                _logger.LogTrace(L($"Sending binary thread failed, error: {e.Message}. Creating a new sending thread."));
                 StartBackgroundThreadForSendingBinary();
             }
 
@@ -187,11 +187,11 @@ namespace Websocket.Client
         {
             if (!IsClientConnected())
             {
-                Logger.Debug(L($"Client is not connected to server, cannot send:  {message}"));
+                _logger.LogDebug(L($"Client is not connected to server, cannot send:  {message}"));
                 return;
             }
 
-            Logger.Trace(L($"Sending:  {message}"));
+            _logger.LogTrace(L($"Sending:  {message}"));
             var buffer = GetEncoding().GetBytes(message);
             var messageSegment = new ArraySegment<byte>(buffer);
             await _client
@@ -211,11 +211,11 @@ namespace Websocket.Client
         {
             if (!IsClientConnected())
             {
-                Logger.Debug(L($"Client is not connected to server, cannot send binary, length: {message.Length}"));
+                _logger.LogDebug(L($"Client is not connected to server, cannot send binary, length: {message.Length}"));
                 return;
             }
 
-            Logger.Trace(L($"Sending binary, length: {message.Length}"));
+            _logger.LogTrace(L($"Sending binary, length: {message.Length}"));
 
             await _client
                 .SendAsync(new ArraySegment<byte>(message), WebSocketMessageType.Binary, true, _cancellation.Token)

--- a/test_integration/Websocket.Client.Sample/Program.cs
+++ b/test_integration/Websocket.Client.Sample/Program.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 
@@ -46,10 +47,12 @@ namespace Websocket.Client.Sample
                 //client.Options.SetRequestHeader("Origin", "xxx");
                 return client;
             });
+            var loggerFactory = LoggerFactory.Create(builder => { builder.AddSerilog(Log.Logger); });
 
             var url = new Uri("wss://www.bitmex.com/realtime");
 
-            using (IWebsocketClient client = new WebsocketClient(url, factory))
+            using (IWebsocketClient client = new WebsocketClient(url, factory,
+                loggerFactory.CreateLogger<WebsocketClient>()))
             {
                 client.Name = "Bitmex";
                 client.ReconnectTimeout = TimeSpan.FromSeconds(30);

--- a/test_integration/Websocket.Client.Sample/Websocket.Client.Sample.csproj
+++ b/test_integration/Websocket.Client.Sample/Websocket.Client.Sample.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />

--- a/test_integration/Websocket.Client.Tests.Integration/Websocket.Client.Tests.Integration.csproj
+++ b/test_integration/Websocket.Client.Tests.Integration/Websocket.Client.Tests.Integration.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.21" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
+++ b/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
@@ -3,6 +3,7 @@ using System.Net.WebSockets;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Xunit;
@@ -243,6 +244,7 @@ namespace Websocket.Client.Tests.Integration
                 .MinimumLevel.Verbose()
                 .WriteTo.TestOutput(output, LogEventLevel.Verbose)
                 .CreateLogger();
+            WebsocketClient.LoggerFactory = LoggerFactory.Create(builder => { builder.AddSerilog(Log.Logger); });
         }
     }
 }


### PR DESCRIPTION
Resolves #46, 

Replaced removed LibLock reference and added ILogger to ctors.
If ILogger passed to ctor is null static ILoggerFactory instance is used to create logger.

Be default i think logger should be passed in ctor, but for easier migration to MS logger static factory was create.

Passing be ctor is used in sample project and static factory is used in Integration test project.

I was thinking about instead of using [NullLoggerFactory](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.abstractions.nullloggerfactory?view=dotnet-plat-ext-3.1) checking if srilog or nlog or any other logger was initialed and use it but that would require reference to those projects which I wanted to avoid.

Because of that this PR is braking change. Migration step required for logger to work as excepted would be to initialize LogerFactory after configuring Logger as shown in 

> test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs line 247 

or swith to ctor as shown in  

> test_integration/Websocket.Client.Sample/Program.cs line 50 to 55

Also updated dotnet projects to net core 3.1