### PR TITLE
returning when the client is already stopped

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -297,6 +297,13 @@ namespace Websocket.Client
                 throw new WebsocketException(L("Client is already disposed, stopping not possible"));
             }
 
+            if(!IsRunning)
+            {
+                Logger.Info(L("Client is already stopped"));
+
+                return false;
+            }
+
             var result = false;
             if (client == null)
             {


### PR DESCRIPTION
After  calling `await _client.Stop(WebSocketCloseStatus.NormalClosure, "Stopping ws").ConfigureAwait(false);`
I get some error log saying "[WEBSOCKET CLIENT] Error while stopping client, message: 'The WebSocket is in an invalid state ('Closed') for this operation. Valid states are: 'Open, CloseReceived''".
I have realized that StopInternal is being called twice, the second time is being called implicetely here https://github.com/Marfusios/websocket-client/blob/master/src/Websocket.Client/WebsocketClient.cs#L486.
Although is not a big problem, it causes unnecessary processment and polutes the logs with that message.
In our case it is inconvenient because we have some alarms regarding error messages patterns.