### PR TITLE
preventing duplicated stop and potential reconnect

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -476,6 +476,12 @@ namespace Websocket.Client
                     else if (result.MessageType == WebSocketMessageType.Close)
                     {
                         Logger.Trace(L($"Received close message"));
+
+                        if(!IsStarted || _stopping)
+                        {
+                            return;
+                        }
+
                         var info = DisconnectionInfo.Create(DisconnectionType.ByServer, client, null);
                         _disconnectedSubject.OnNext(info);
 

--- a/test/Websocket.Client.Tests/ConnectionTests.cs
+++ b/test/Websocket.Client.Tests/ConnectionTests.cs
@@ -405,6 +405,55 @@ namespace Websocket.Client.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Stopping_ByUser_NormalClosure_ShouldntTriggerReconnect(bool reconnectionEnabled)
+        {
+            using (var client = _context.CreateClient())
+            {
+                // independently of this config, if it is a normal expected closure by User, it shouldn't reconnect
+                client.IsReconnectionEnabled = reconnectionEnabled;
+                client.ReconnectTimeout = TimeSpan.FromSeconds(7);
+
+                var reconnectionCount = 0;
+                var disconnectionCount = 0;
+
+                DisconnectionInfo disconnectionInfo = null;
+
+                client.DisconnectionHappened.Subscribe(x =>
+                {
+                    disconnectionCount++;
+                    disconnectionInfo = x;
+                });
+
+                client.ReconnectionHappened.Subscribe(x =>
+                {
+                    if (x.Type != ReconnectionType.Initial)
+                    {
+                        reconnectionCount++;
+                    }
+                });
+
+                await client.Start();
+
+                client.Send("ping");
+
+                await client.Stop(WebSocketCloseStatus.NormalClosure, "Expected Closure");
+
+                // give some time to receive disconnection and reconnection messages
+                await Task.Delay(5000);
+
+                Assert.Equal(1, disconnectionCount);
+                Assert.Equal(0, reconnectionCount);
+                Assert.Equal(DisconnectionType.ByUser, disconnectionInfo.Type);
+                Assert.Equal(WebSocketCloseStatus.NormalClosure, disconnectionInfo.CloseStatus);
+                Assert.Equal("Expected Closure", disconnectionInfo.CloseStatusDescription);
+                Assert.False(client.IsRunning);
+                Assert.False(client.IsStarted);
+            }
+        }
+
         [Fact]
         public async Task Dispose_ShouldWorkCorrectly()
         {


### PR DESCRIPTION
Hi,

I am experiencing an issue that when I am stoping the client with `NormalClosure` status, I receive 2 times the DisconnectionHappened message (one ByUser and another ByServer) and also a RecconnectionHappened message.
The bigger problem here is with the ReconnectionHappened message because it means that the client is reconnecting even when is expected to stop (since it is an explicit stop), which causes the connection to be kept open.
I was debugging and I've realized that the code execution hits here https://github.com/imaramos/websocket-client/blob/1271798fb59d5ec3d0720d3d70f9d1a85843e720/src/Websocket.Client/WebsocketClient.cs#L485, here https://github.com/imaramos/websocket-client/blob/1271798fb59d5ec3d0720d3d70f9d1a85843e720/src/Websocket.Client/WebsocketClient.cs#L499 and here https://github.com/imaramos/websocket-client/blob/1271798fb59d5ec3d0720d3d70f9d1a85843e720/src/Websocket.Client/WebsocketClient.cs#L505.
Apparently, when you stop the client explicitly, the server returns a WebsoketMessageType.Close message and that's the reason the code hits this if statement https://github.com/imaramos/websocket-client/blob/1271798fb59d5ec3d0720d3d70f9d1a85843e720/src/Websocket.Client/WebsocketClient.cs#L477.
With these changes, I am avoiding this duplicated stop and also the reconnect.

This is not an easy issue to replicate, but you can replicate it by running something like this a  couple of times:

```
var client = new WebsocketClient(endpoint)
{
    ErrorReconnectTimeout = TimeSpan.FromSeconds(30),
    ReconnectTimeout = TimeSpan.FromMinutes(2)
};

await client.StartOrFail();

client.ReconnectionHappened.Subscribe(
    info =>
    {
        _logger.LogInformation($"Reconnected, type {info.Type}");
    }, cancellationToken);

client.DisconnectionHappened.Subscribe(
    info =>
    {
        _logger.LogInformation($"Disconnected, type {info.Type}");
    }, cancellationToken);
		
await _client.SendInstant(subscriptionMessage).ConfigureAwait(false);

_client.MessageReceived.Subscribe(
message =>
{
    try
    {
        _logger.LogInformation($"Received message {message.Text}");
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, "Unable to process message");
    }
}, cancellationToken);

await Task.Delay(7000);

await _client.Stop(WebSocketCloseStatus.NormalClosure, "Expected closure");
```

