### PR TITLE
call onnext before listen.

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -351,9 +351,9 @@ namespace Websocket.Client
             try
             {
                 _client = await _connectionFactory(uri, token).ConfigureAwait(false);
+                _ = Listen(_client, token);
                 IsRunning = true;
                 IsStarted = true;
-                _ = Listen(_client, token);
                 _reconnectionSubject.OnNext(ReconnectionInfo.Create(type));
                 _lastReceivedMsg = DateTime.UtcNow;
                 ActivateLastChance();

--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -353,8 +353,8 @@ namespace Websocket.Client
                 _client = await _connectionFactory(uri, token).ConfigureAwait(false);
                 IsRunning = true;
                 IsStarted = true;
-                _reconnectionSubject.OnNext(ReconnectionInfo.Create(type));
                 _ = Listen(_client, token);
+                _reconnectionSubject.OnNext(ReconnectionInfo.Create(type));
                 _lastReceivedMsg = DateTime.UtcNow;
                 ActivateLastChance();
             }

--- a/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
+++ b/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
@@ -226,7 +226,7 @@ namespace Websocket.Client.Tests.Integration
                 Assert.Equal(DisconnectionType.ByUser, disconnectionInfo.Type);
                 Assert.Equal(WebSocketCloseStatus.InternalServerError, disconnectionInfo.CloseStatus);
                 Assert.Equal("server error 500", disconnectionInfo.CloseStatusDescription);
-                Assert.Equal(WebSocketState.Aborted, nativeClient.State);
+                Assert.Equal(WebSocketState.Closed, nativeClient.State);
                 Assert.Equal(WebSocketCloseStatus.InternalServerError, nativeClient.CloseStatus);
                 Assert.Equal("server error 500", nativeClient.CloseStatusDescription);
 

--- a/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
+++ b/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
@@ -226,7 +226,7 @@ namespace Websocket.Client.Tests.Integration
                 Assert.Equal(DisconnectionType.ByUser, disconnectionInfo.Type);
                 Assert.Equal(WebSocketCloseStatus.InternalServerError, disconnectionInfo.CloseStatus);
                 Assert.Equal("server error 500", disconnectionInfo.CloseStatusDescription);
-                Assert.Equal(WebSocketState.Closed, nativeClient.State);
+                Assert.Equal(WebSocketState.Aborted, nativeClient.State);
                 Assert.Equal(WebSocketCloseStatus.InternalServerError, nativeClient.CloseStatus);
                 Assert.Equal("server error 500", nativeClient.CloseStatusDescription);
 


### PR DESCRIPTION
Since there are occasions that the socket needs to be authenticated first, it can be better to call Listen first and send the auth message in the ReconnectionHappened dele. In case it might miss the response.