### PR TITLE
Call Listen after setting IsRunning and calling OnNext.

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -351,10 +351,10 @@ namespace Websocket.Client
             try
             {
                 _client = await _connectionFactory(uri, token).ConfigureAwait(false);
+                _ = Listen(_client, token);
                 IsRunning = true;
                 IsStarted = true;
                 _reconnectionSubject.OnNext(ReconnectionInfo.Create(type));
-                _ = Listen(_client, token);
                 _lastReceivedMsg = DateTime.UtcNow;
                 ActivateLastChance();
             }


### PR DESCRIPTION
Since there are occasions that the socket needs to be authenticated first, it can be better to call Listen first and send the auth message in the ReconnectionHappened dele. In case it might miss the response.