### PR TITLE
Add Sending of ArraySegments

### DIFF
--- a/src/Websocket.Client/IWebsocketClient.cs
+++ b/src/Websocket.Client/IWebsocketClient.cs
@@ -126,6 +126,13 @@ namespace Websocket.Client
         void Send(byte[] message);
 
         /// <summary>
+        /// Send binary message to the websocket channel. 
+        /// It inserts the message to the queue and actual sending is done on an other thread
+        /// </summary>
+        /// <param name="message">Binary message to be sent</param>
+        void Send(ArraySegment<byte> message);
+
+        /// <summary>
         /// Send message to the websocket channel. 
         /// It doesn't use a sending queue, 
         /// beware of issue while sending two messages in the exact same time 

--- a/src/Websocket.Client/WebsocketClient.Sending.cs
+++ b/src/Websocket.Client/WebsocketClient.Sending.cs
@@ -49,7 +49,7 @@ namespace Websocket.Client
         /// It inserts the message to the queue and actual sending is done on an other thread
         /// </summary>
         /// <param name="message">Binary message to be sent</param>
-        public void Send(ref ArraySegment<byte> message)
+        public void Send(ArraySegment<byte> message)
         {
             Validations.Validations.ValidateInput(message, nameof(message));
 

--- a/src/Websocket.Client/WebsocketClient.Sending.cs
+++ b/src/Websocket.Client/WebsocketClient.Sending.cs
@@ -13,7 +13,7 @@ namespace Websocket.Client
             SingleReader = true,
             SingleWriter = false
         });
-        private readonly Channel<byte[]> _messagesBinaryToSendQueue = Channel.CreateUnbounded<byte[]>(new UnboundedChannelOptions()
+        private readonly Channel<ArraySegment<byte>> _messagesBinaryToSendQueue = Channel.CreateUnbounded<ArraySegment<byte>>(new UnboundedChannelOptions()
         {
             SingleReader = true,
             SingleWriter = false
@@ -38,6 +38,18 @@ namespace Websocket.Client
         /// </summary>
         /// <param name="message">Binary message to be sent</param>
         public void Send(byte[] message)
+        {
+            Validations.Validations.ValidateInput(message, nameof(message));
+
+            _messagesBinaryToSendQueue.Writer.TryWrite(new ArraySegment<byte>(message));
+        }
+
+        /// <summary>
+        /// Send binary message to the websocket channel. 
+        /// It inserts the message to the queue and actual sending is done on an other thread
+        /// </summary>
+        /// <param name="message">Binary message to be sent</param>
+        public void Send(ref ArraySegment<byte> message)
         {
             Validations.Validations.ValidateInput(message, nameof(message));
 
@@ -67,7 +79,7 @@ namespace Websocket.Client
         /// <param name="message">Message to be sent</param>
         public Task SendInstant(byte[] message)
         {
-            return SendInternalSynchronized(message);
+            return SendInternalSynchronized(new ArraySegment<byte>(message));
         }
 
         /// <summary>
@@ -199,7 +211,7 @@ namespace Websocket.Client
                 .ConfigureAwait(false);
         }
 
-        private async Task SendInternalSynchronized(byte[] message)
+        private async Task SendInternalSynchronized(ArraySegment<byte> message)
         {
             using (await _locker.LockAsync())
             {
@@ -207,18 +219,18 @@ namespace Websocket.Client
             }
         }
 
-        private async Task SendInternal(byte[] message)
+        private async Task SendInternal(ArraySegment<byte> message)
         {
             if (!IsClientConnected())
             {
-                Logger.Debug(L($"Client is not connected to server, cannot send binary, length: {message.Length}"));
+                Logger.Debug(L($"Client is not connected to server, cannot send binary, length: {message.Count}"));
                 return;
             }
 
-            Logger.Trace(L($"Sending binary, length: {message.Length}"));
+            Logger.Trace(L($"Sending binary, length: {message.Count}"));
 
             await _client
-                .SendAsync(new ArraySegment<byte>(message), WebSocketMessageType.Binary, true, _cancellation.Token)
+                .SendAsync(message, WebSocketMessageType.Binary, true, _cancellation.Token)
                 .ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Native Client Supports ArraySegment Sending but the wrapper doesn't it only supports the sending of byte Arrays, if things are about performance or allocations it makes more sense to send ArraySegments than byte arrays, so this Change fixes this flaw and allows sending of ArraySegments with this Library