### PR TITLE
Fix: catching Blazor WebAssembly WebSocket client aborting exception.

### DIFF
--- a/src/Websocket.Client/WebsocketClient.Reconnecting.cs
+++ b/src/Websocket.Client/WebsocketClient.Reconnecting.cs
@@ -75,7 +75,14 @@ namespace Websocket.Client
             }
                 
             _cancellation.Cancel();
-            _client?.Abort();
+            try
+            {
+                _client?.Abort();
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, L($"Exception while aborting client. " + $"Error: '{e.Message}'"));
+            }
             _client?.Dispose();
 
             if (!IsReconnectionEnabled || disInfo.CancelReconnection)


### PR DESCRIPTION
Im using websocket-client in Blazor WebAssembly project. And sometimes i'm facing with this exception, which crash reconnecting flow:

`[WEBSOCKET wss://my-pet-project] Exception while aborting client. Error: 'Error releasing object on (obj)' 
 WebAssembly.JSException: Error releasing object on (obj)
  at WebAssembly.Runtime.FreeObject (System.Object obj) <0x3bf0cb0 + 0x000da> in <filename unknown>:0 
  at WebAssembly.Net.WebSockets.ClientWebSocket.Dispose () <0x3bef868 + 0x000dc> in <filename unknown>:0 
  at WebAssembly.Net.WebSockets.ClientWebSocket.Abort () <0x3bef710 + 0x0002a> in <filename unknown>:0 
  at System.Net.WebSockets.WebSocketHandle.Abort () <0x3bef650 + 0x00014> in <filename unknown>:0 
  at System.Net.WebSockets.ClientWebSocket.Abort () <0x3bef5e0 + 0x00028> in <filename unknown>:0 
  at Websocket.Client.WebsocketClient.Reconnect (Websocket.Client.ReconnectionType type, System.Boolean failFast, System.Exception causedException) [0x00198] in /Users/aliceandbob/Projects/websocket-client/src/Websocket.Client/WebsocketClient.Reconnecting.cs:78`
  
  It happens on this call: https://github.com/Marfusios/websocket-client/blob/f8e776502abfc61696d13a56f112d9a991a26749/src/Websocket.Client/WebsocketClient.Reconnecting.cs#L78
  
  Wrapping this in try/catch do the trick.