### PR TITLE
Fixed the issue in #114: Disposing an inactive WebsocketClient no longer triggers DisconnectionHappened

### DIFF
--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -191,9 +191,13 @@ namespace Websocket.Client
                 Logger.Error(e, L($"Failed to dispose client, error: {e.Message}"));
             }
 
+            if (IsRunning) 
+            {
+                _disconnectedSubject.OnNext(DisconnectionInfo.Create(DisconnectionType.Exit, _client, null));
+            }
+
             IsRunning = false;
             IsStarted = false;
-            _disconnectedSubject.OnNext(DisconnectionInfo.Create(DisconnectionType.Exit, _client, null));
             _disconnectedSubject.OnCompleted();
         }
 


### PR DESCRIPTION
See #114.

I updated a test to catch this new behavior, and then I updated the code accordingly (this only required a tiny change).
