### PR TITLE
Use RecyclableMemoryStream instead of MemoryStream

### DIFF
--- a/src/Websocket.Client/RequestMessage.cs
+++ b/src/Websocket.Client/RequestMessage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Websocket.Client
+{
+    internal abstract class RequestMessage { }
+
+    internal class RequestTextMessage : RequestMessage
+    {
+        public string Text { get; }
+
+        public RequestTextMessage(string text)
+        {
+            Text = text;
+        }
+    }
+
+    internal class RequestBinaryMessage : RequestMessage
+    {
+        public byte[] Data { get; }
+
+        public RequestBinaryMessage(byte[] data)
+        {
+            Data = data;
+        }
+    }
+
+    internal class RequestBinarySegmentMessage : RequestMessage
+    {
+        public ArraySegment<byte> Data { get; }
+
+        public RequestBinarySegmentMessage(ArraySegment<byte> data)
+        {
+            Data = data;
+        }
+    }
+}

--- a/src/Websocket.Client/Websocket.Client.csproj
+++ b/src/Websocket.Client/Websocket.Client.csproj
@@ -29,6 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+		<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
 		<PackageReference Include="System.Reactive" Version="6.0.0" />
 		<PackageReference Include="System.Threading.Channels" Version="7.0.0" />
 	</ItemGroup>

--- a/src/Websocket.Client/WebsocketClient.Sending.cs
+++ b/src/Websocket.Client/WebsocketClient.Sending.cs
@@ -299,24 +299,7 @@ namespace Websocket.Client
             }
 
             _logger.LogTrace(L("Sending: {message}"), Name, message);
-#if NETSTANDARD2_0
-            ArraySegment<byte> payload;
 
-            switch (message)
-            {
-                case RequestTextMessage textMessage:
-                    payload = new ArraySegment<byte>(GetEncoding().GetBytes(textMessage.Text));
-                    break;
-                case RequestBinaryMessage binaryMessage:
-                    payload = new ArraySegment<byte>(binaryMessage.Data);
-                    break;
-                case RequestBinarySegmentMessage segmentMessage:
-                    payload = segmentMessage.Data;
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown message type: {message.GetType()}");
-            }
-#else
             ReadOnlyMemory<byte> payload;
 
             switch (message)
@@ -333,7 +316,6 @@ namespace Websocket.Client
                 default:
                     throw new ArgumentException($"Unknown message type: {message.GetType()}");
             }
-#endif
 
             await _client!
                 .SendAsync(payload, WebSocketMessageType.Text, true, _cancellation?.Token ?? CancellationToken.None)

--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -453,30 +453,17 @@ namespace Websocket.Client
             {
                 // define buffer here and reuse, to avoid more allocation
                 const int chunkSize = 1024 * 4;
-#if NETSTANDARD2_0
-                var buffer = new ArraySegment<byte>(new byte[chunkSize]);
-#else
                 var buffer = new Memory<byte>(new byte[chunkSize]);
-#endif
 
                 do
                 {
-#if NETSTANDARD2_0
-                    WebSocketReceiveResult result;
-#else
                     ValueWebSocketReceiveResult result;
-#endif
                     var ms = _memoryStreamManager.GetStream() as RecyclableMemoryStream;
 
                     while (true)
                     {
                         result = await client.ReceiveAsync(buffer, token);
-
-#if NETSTANDARD2_0
-                        ms.Write(buffer.AsSpan(0, result.Count));
-#else
-                        ms.Write(buffer[..result.Count].Span);
-#endif
+                        ms!.Write(buffer[..result.Count].Span);
 
                         if (result.EndOfMessage)
                             break;


### PR DESCRIPTION
What is done on this PR:

* Make use of a `RecyclableMemoryStreamManager` from the `Microsoft.IO.RecyclableMemoryStream` to recycle `MemoryStream` instead of having extensive use of the Garbage Collector. More info here: https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream

I have a benchmark in place for a project I am working on. Here are the result benchmarks.

Before:

|                Method |       Mean |    Error |   StdDev |    Gen0 |    Gen1 |  Allocated |
|---------------------- |-----------:|---------:|---------:|--------:|--------:|-----------:|
| HttpWithClientFactory | 1,036.2 μs |  8.33 μs |  7.79 μs | 15.6250 |  3.9063 |  253.87 KB |
|                WsText | 4,626.6 μs | 49.26 μs | 43.67 μs | 39.0625 | 15.6250 | 2675.36 KB |
|              WsBinary |         NA |       NA |       NA |      NA |      NA |         NA |

After:

|                Method |       Mean |    Error |   StdDev |    Gen0 |   Gen1 |  Allocated |
|---------------------- |-----------:|---------:|---------:|--------:|-------:|-----------:|
| HttpWithClientFactory | 1,033.3 us |  4.92 us |  4.37 us | 15.6250 | 3.9063 |  253.67 KB |
|                WsText | 3,212.6 us | 60.18 us | 53.34 us | 27.3438 | 7.8125 | 1166.44 KB |
|              WsBinary |         NA |       NA |       NA |      NA |     NA |         NA |

I put the `HttpWithClientFactory` in reference because it should have a very close performance impact to `WsText`. CPU time and memory allocation are reduced by 80%-120%. Of course, it depends on the use case. For some scenarii, there are absolutely no impact (small batch, few/no data consumption).  