### PR TITLE
Add support for cooperative cancellation

### DIFF
--- a/src/Websocket.Client/IWebsocketClient.cs
+++ b/src/Websocket.Client/IWebsocketClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.WebSockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Websocket.Client
@@ -95,28 +96,28 @@ namespace Websocket.Client
         /// In case of connection error it doesn't throw an exception.
         /// Only streams a message via 'DisconnectionHappened' and logs it. 
         /// </summary>
-        Task Start();
+        Task Start(CancellationToken cancellation = default);
 
         /// <summary>
         /// Start listening to the websocket stream on the background thread. 
         /// In case of connection error it throws an exception.
         /// Fail fast approach. 
         /// </summary>
-        Task StartOrFail();
+        Task StartOrFail(CancellationToken cancellation = default);
 
         /// <summary>
         /// Stop/close websocket connection with custom close code.
         /// Method doesn't throw exception, only logs it and mark client as closed. 
         /// </summary>
         /// <returns>Returns true if close was initiated successfully</returns>
-        Task<bool> Stop(WebSocketCloseStatus status, string statusDescription);
+        Task<bool> Stop(WebSocketCloseStatus status, string statusDescription, CancellationToken cancellation = default);
 
         /// <summary>
         /// Stop/close websocket connection with custom close code.
         /// Method could throw exceptions, but client is marked as closed anyway.
         /// </summary>
         /// <returns>Returns true if close was initiated successfully</returns>
-        Task<bool> StopOrFail(WebSocketCloseStatus status, string statusDescription);
+        Task<bool> StopOrFail(WebSocketCloseStatus status, string statusDescription, CancellationToken cancellation = default);
 
         /// <summary>
         /// Send message to the websocket channel. 
@@ -149,7 +150,8 @@ namespace Websocket.Client
         /// on the full .NET Framework platform
         /// </summary>
         /// <param name="message">Message to be sent</param>
-        Task SendInstant(string message);
+        /// <param name="cancellation">Cancellation token</param>
+        Task SendInstant(string message, CancellationToken cancellation = default);
 
         /// <summary>
         /// Send binary message to the websocket channel. 
@@ -158,7 +160,8 @@ namespace Websocket.Client
         /// on the full .NET Framework platform
         /// </summary>
         /// <param name="message">Message to be sent</param>
-        Task SendInstant(byte[] message);
+        /// <param name="cancellation">Cancellation token</param>
+        Task SendInstant(byte[] message, CancellationToken cancellation = default);
 
         /// <summary>
         /// Send already converted text message to the websocket channel. 
@@ -183,14 +186,14 @@ namespace Websocket.Client
         /// Closes current websocket stream and perform a new connection to the server.
         /// In case of connection error it doesn't throw an exception, but tries to reconnect indefinitely. 
         /// </summary>
-        Task Reconnect();
+        Task Reconnect(CancellationToken cancellation = default);
 
         /// <summary>
         /// Force reconnection. 
         /// Closes current websocket stream and perform a new connection to the server.
         /// In case of connection error it throws an exception and doesn't perform any other reconnection try. 
         /// </summary>
-        Task ReconnectOrFail();
+        Task ReconnectOrFail(CancellationToken cancellation = default);
 
         /// <summary>
         /// Stream/publish fake message (via 'MessageReceived' observable).

--- a/src/Websocket.Client/Threading/WebsocketAsyncLock.cs
+++ b/src/Websocket.Client/Threading/WebsocketAsyncLock.cs
@@ -43,9 +43,9 @@ namespace Websocket.Client.Threading
         /// <summary>
         /// Use inside 'using' block with await
         /// </summary>
-        public Task<IDisposable> LockAsync()
+        public Task<IDisposable> LockAsync(CancellationToken cancellation = default)
         {
-            var waitTask = _semaphore.WaitAsync();
+            var waitTask = _semaphore.WaitAsync(cancellation);
             return waitTask.IsCompleted
                 ? _releaserTask
                 : waitTask.ContinueWith(

--- a/src/Websocket.Client/WebsocketClient.Reconnecting.cs
+++ b/src/Websocket.Client/WebsocketClient.Reconnecting.cs
@@ -97,8 +97,10 @@ namespace Websocket.Client
             }
 
             _logger.LogDebug(L("Reconnecting..."), Name);
-            _cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
-            await StartClient(_url, _cancellation.Token, type, failFast).ConfigureAwait(false);
+            _cancellation = new CancellationTokenSource();
+            
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancellation.Token, cancellation);
+            await StartClient(_url, cts.Token, type, failFast).ConfigureAwait(false);
             _reconnecting = false;
         }
 


### PR DESCRIPTION
Hello. I've found this package in the process of replacing a different older package. The older package didn't offer any async/await anyway, so this one is already an improvement.

I've noticed that methods I would normally expect to support cancellation just don't. 

I'd like to be able to pass a cancellation token of my own to `Start`, `StartOrFail`, `Stop`, `StopOrFail`.

I see you already internally manage a cancellation token and pass it on to the real underlying method calls to the websocket client. Could you provide overloads that allow me to pass my own token and link to it? 

I'm not quite sure I've implemented the cancellation in the way you would have liked, so please use my PR as a suggestion. (I'm not sure how you'd like to combine with the cancellation token source you save at the class instance level) 

There are considerations. Should then token passed into `Start` be able to also cancel the whole `Listen` process after `Start` has finished? Arguably not. Feel free to modify my code as you see fit.