### PR TITLE
Support ReadOnlySequence type

### DIFF
--- a/src/Websocket.Client/RequestMessage.cs
+++ b/src/Websocket.Client/RequestMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 
 namespace Websocket.Client
 {
@@ -29,6 +30,16 @@ namespace Websocket.Client
         public ArraySegment<byte> Data { get; }
 
         public RequestBinarySegmentMessage(ArraySegment<byte> data)
+        {
+            Data = data;
+        }
+    }
+
+    internal class RequestBinarySequenceMessage : RequestMessage
+    {
+        public ReadOnlySequence<byte> Data { get; }
+
+        public RequestBinarySequenceMessage(ReadOnlySequence<byte> data)
         {
             Data = data;
         }

--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -458,7 +458,7 @@ namespace Websocket.Client
                 do
                 {
                     ValueWebSocketReceiveResult result;
-                    var ms = (RecyclableMemoryStream)_memoryStreamManager.GetStream();
+                    var ms = _memoryStreamManager.GetStream();
 
                     while (true)
                     {


### PR DESCRIPTION
Support `ReadOnlySequence<byte>` type on Send methods:

* for both `TEXT` and `BINARY` websocket message types
* Handle `ReadOnlyMemory<byte>` type (internally for now)
* may have performance benefits to read memory block by block on large sequences (multiple segments)