### PR TITLE
Fix bugs in Reconnect logic

### DIFF
--- a/src/Websocket.Client/IWebsocketClient.cs
+++ b/src/Websocket.Client/IWebsocketClient.cs
@@ -117,6 +117,12 @@ namespace Websocket.Client
         IObservable<DisconnectionInfo> DisconnectionHappened { get; }
 
         /// <summary>
+        /// Time range for how long to wait while connecting a new client.
+        /// Default: 2 seconds
+        /// </summary>
+        TimeSpan ConnectTimeout { get; set; }
+
+        /// <summary>
         /// Time range for how long to wait before reconnecting if no message comes from server.
         /// Set null to disable this feature. 
         /// Default: 1 minute

--- a/src/Websocket.Client/IWebsocketClient.cs
+++ b/src/Websocket.Client/IWebsocketClient.cs
@@ -159,6 +159,21 @@ namespace Websocket.Client
         bool IsRunning { get; }
 
         /// <summary>
+        /// Returns whether text message sender is running.
+        /// </summary>
+        bool TextSenderRunning { get; }
+
+        /// <summary>
+        /// Returns whether the binary message sender is running.
+        /// </summary>
+        bool BinarySenderRunning { get; }
+
+        /// <summary>
+        /// Indicates whether any thread has entered the lock.
+        /// </summary>
+        bool IsInsideLock { get; }
+
+        /// <summary>
         /// Enable or disable text message conversion from binary to string (via 'MessageEncoding' property).
         /// Default: true
         /// </summary>

--- a/src/Websocket.Client/Threading/WebsocketAsyncLock.cs
+++ b/src/Websocket.Client/Threading/WebsocketAsyncLock.cs
@@ -32,6 +32,11 @@ namespace Websocket.Client.Threading
         }
 
         /// <summary>
+        /// True if the lock is currently taken
+        /// </summary>
+        public bool IsLocked => _semaphore.CurrentCount == 0;
+
+        /// <summary>
         /// Use inside 'using' block
         /// </summary>
         public IDisposable Lock()

--- a/src/Websocket.Client/WebsocketClient.Reconnecting.cs
+++ b/src/Websocket.Client/WebsocketClient.Reconnecting.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -67,7 +68,7 @@ namespace Websocket.Client
 
             var disType = TranslateTypeToDisconnection(type);
             var disInfo = DisconnectionInfo.Create(disType, _client, causedException);
-            if (type != ReconnectionType.Error)
+            if (type != ReconnectionType.Error && _client?.State != WebSocketState.CloseReceived && _client?.State != WebSocketState.Closed)
             {
                 _disconnectedSubject.OnNext(disInfo);
                 if (disInfo.CancelReconnection)

--- a/src/Websocket.Client/WebsocketClient.Reconnecting.cs
+++ b/src/Websocket.Client/WebsocketClient.Reconnecting.cs
@@ -89,7 +89,7 @@ namespace Websocket.Client
             }
             _client?.Dispose();
 
-            if (!IsReconnectionEnabled || disInfo.CancelReconnection)
+            if (type != ReconnectionType.Error && (!IsReconnectionEnabled || disInfo.CancelReconnection))
             {
                 // reconnection disabled, do nothing
                 IsStarted = false;

--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -189,6 +189,9 @@ namespace Websocket.Client
         /// Default: true
         /// </summary>
         public bool IsTextMessageConversionEnabled { get; set; } = true;
+        
+        /// <inheritdoc />
+        public bool IsInsideLock => _locker.IsLocked;
 
         /// <summary>
         /// Enable or disable automatic <see cref="MemoryStream.Dispose(bool)"/> of the <see cref="MemoryStream"/> 
@@ -491,7 +494,7 @@ namespace Websocket.Client
                     }
                     else if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        _logger.LogTrace(L("Received close message"), Name);
+                        _logger.LogDebug(L("Received close message"), Name);
 
                         if (!IsStarted || _stopping)
                         {

--- a/src/Websocket.Client/WebsocketClient.cs
+++ b/src/Websocket.Client/WebsocketClient.cs
@@ -515,13 +515,12 @@ namespace Websocket.Client
                             continue;
                         }
 
-                        await StopInternal(client, WebSocketCloseStatus.NormalClosure, "Closing",
-                            token, false, true);
+                        await StopInternal(client, WebSocketCloseStatus.NormalClosure, "Closing", token, false, true);
 
                         // reconnect if enabled
                         if (IsReconnectionEnabled && !ShouldIgnoreReconnection(client))
                         {
-                            _ = ReconnectSynchronized(ReconnectionType.Lost, false, null);
+                            _ = ReconnectSynchronized(ReconnectionType.ByServer, false, null);
                         }
 
                         return;

--- a/test/Websocket.Client.Tests/ConnectionTests.cs
+++ b/test/Websocket.Client.Tests/ConnectionTests.cs
@@ -139,6 +139,7 @@ namespace Websocket.Client.Tests
 
             foreach (var client in clients)
             {
+                await client.Start();
                 client.Send("ping");
             }
 
@@ -243,7 +244,7 @@ namespace Websocket.Client.Tests
             await WaitUntil(() => !client.IsStarted);
 
             Assert.Equal(1, receivedCount);
-            Assert.InRange(disconnectionCount, 1, 2);
+            Assert.Equal(1, disconnectionCount);
             Assert.Equal(DisconnectionType.ByServer, disconnectionInfo.Type);
             Assert.Equal(WebSocketCloseStatus.NormalClosure, disconnectionInfo.CloseStatus);
             Assert.Equal("normal closure", disconnectionInfo.CloseStatusDescription);
@@ -289,8 +290,8 @@ namespace Websocket.Client.Tests
             await WaitUntil(() => receivedCount == 2);
 
             Assert.Equal(2, receivedCount);
-            Assert.InRange(disconnectionCount, 1, 2);
-            Assert.Equal(DisconnectionType.Lost, disconnectionInfo.Type);
+            Assert.Equal(1, disconnectionCount);
+            Assert.Equal(DisconnectionType.ByServer, disconnectionInfo.Type);
             Assert.Equal(WebSocketCloseStatus.NormalClosure, disconnectionInfo.CloseStatus);
             Assert.Equal("normal closure", disconnectionInfo.CloseStatusDescription);
             Assert.True(client.IsRunning);
@@ -336,8 +337,8 @@ namespace Websocket.Client.Tests
             await WaitUntil(() => !client.IsStarted);
 
             Assert.Equal(1, receivedCount);
-            Assert.InRange(disconnectionCount, 1, 2);
-            Assert.Equal(DisconnectionType.Lost, disconnectionInfo.Type);
+            Assert.Equal(1, disconnectionCount);
+            Assert.Equal(DisconnectionType.ByServer, disconnectionInfo.Type);
             Assert.Equal(WebSocketCloseStatus.NormalClosure, disconnectionInfo.CloseStatus);
             Assert.Equal("normal closure", disconnectionInfo.CloseStatusDescription);
             Assert.False(client.IsRunning);
@@ -383,8 +384,8 @@ namespace Websocket.Client.Tests
             await WaitUntil(() => receivedCount == 2);
 
             Assert.Equal(2, receivedCount);
-            Assert.InRange(disconnectionCount, 1, 2);
-            Assert.Equal(DisconnectionType.Lost, disconnectionInfo.Type);
+            Assert.Equal(1, disconnectionCount);
+            Assert.Equal(DisconnectionType.ByServer, disconnectionInfo.Type);
             Assert.Equal(WebSocketCloseStatus.NormalClosure, disconnectionInfo.CloseStatus);
             Assert.Equal("normal closure", disconnectionInfo.CloseStatusDescription);
             Assert.True(client.IsRunning);

--- a/test/Websocket.Client.Tests/ReconnectionTests.cs
+++ b/test/Websocket.Client.Tests/ReconnectionTests.cs
@@ -29,7 +29,7 @@ namespace Websocket.Client.Tests
             var receivedEvent = new ManualResetEvent(false);
 
             client.IsReconnectionEnabled = true;
-            client.ReconnectTimeout = TimeSpan.FromSeconds(3);
+            client.ReconnectTimeout = TimeSpan.FromMilliseconds(50);
 
             client.MessageReceived
                 .Where(x => x.MessageType == WebSocketMessageType.Text)
@@ -40,7 +40,7 @@ namespace Websocket.Client.Tests
                 });
 
             await client.Start();
-            await Task.Delay(12000);
+            await Task.Delay(2200);
 
             _output.WriteLine($"Reconnected {receivedCount} times");
             Assert.InRange(receivedCount, 2, 7);
@@ -67,13 +67,13 @@ namespace Websocket.Client.Tests
                 });
 
             await client.Start();
-            await Task.Delay(3000);
+            await Task.Delay(300);
             await client.Stop(WebSocketCloseStatus.InternalServerError, "something strange happened");
 
-            await Task.Delay(3000);
+            await Task.Delay(300);
 
             await client.Start();
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
             receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
 
@@ -101,10 +101,10 @@ namespace Websocket.Client.Tests
                 });
 
             await client.Start();
-            await Task.Delay(3000);
+            await Task.Delay(300);
             await client.Reconnect();
 
-            await Task.Delay(3000);
+            await Task.Delay(300);
 
             receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
 
@@ -118,7 +118,7 @@ namespace Websocket.Client.Tests
             var receivedCount = 0;
 
             client.IsReconnectionEnabled = true;
-            client.ReconnectTimeout = TimeSpan.FromSeconds(1);
+            client.ReconnectTimeout = TimeSpan.FromMilliseconds(200);
 
             client.MessageReceived.Subscribe(msg =>
             {
@@ -129,7 +129,7 @@ namespace Websocket.Client.Tests
             });
 
             await client.Start();
-            await Task.Delay(7000);
+            await Task.Delay(1200);
 
             Assert.Equal(2, receivedCount);
         }
@@ -162,16 +162,16 @@ namespace Websocket.Client.Tests
 
             await client.Start();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(2000);
+            await Task.Delay(200);
 
             _output.WriteLine($"Received message {receivedCount} times and reconnected {receivedCount} times, " +
                               $"last: {lastReconnectionType}");
@@ -208,24 +208,24 @@ namespace Websocket.Client.Tests
 
             await client.Start();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
             _ = client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
             await client.ReconnectOrFail();
             await client.ReconnectOrFail();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.ReconnectOrFail();
             await client.Reconnect();
             await client.ReconnectOrFail();
 
-            await Task.Delay(8000);
+            await Task.Delay(200);
 
             _output.WriteLine($"Received message {receivedCount} times and reconnected {receivedCount} times, " +
                               $"last: {lastReconnectionType}");
@@ -271,7 +271,7 @@ namespace Websocket.Client.Tests
 
             await client.Start();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
             client.Url = new Uri("wss://google.com");
 
@@ -286,7 +286,7 @@ namespace Websocket.Client.Tests
                 causedException = e;
             }
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
             Assert.Equal(2, disconnectionCount);
             Assert.Equal(DisconnectionType.Error, disconnectionInfo.Type);
@@ -338,16 +338,16 @@ namespace Websocket.Client.Tests
 
             await client.Start();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
             await client.Reconnect();
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
             Assert.Equal(2, disconnectionCount);
             Assert.Equal(DisconnectionType.ByUser, disconnectionInfo.Type);

--- a/test/Websocket.Client.Tests/SendingTests.cs
+++ b/test/Websocket.Client.Tests/SendingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Reactive.Linq;
 using System.Threading;
@@ -158,17 +159,17 @@ namespace Websocket.Client.Tests
             client.Send("ping");
             client.Send("ping");
 
-            await Task.Delay(1000);
-            receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
+            await Task.Delay(100);
+            receivedEvent.WaitOne(TimeSpan.FromSeconds(Debugger.IsAttached ? 30 : 3));
 
             client.Dispose();
 
-            await Task.Delay(2000);
+            await Task.Delay(200);
 
             client.Send("ping");
             await client.SendInstant("ping");
 
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
             Assert.NotNull(received);
             Assert.Equal(3, receivedCount);

--- a/test/Websocket.Client.Tests/Testserver/SimpleStartup.cs
+++ b/test/Websocket.Client.Tests/Testserver/SimpleStartup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
@@ -27,6 +28,9 @@ namespace Websocket.Client.Tests.TestServer
                 {
                     if (context.WebSockets.IsWebSocketRequest)
                     {
+                        if (context.Request.Query.TryGetValue("delay", out var delayValues) && int.TryParse(delayValues, out var delayMilliseconds))
+                            await Task.Delay(delayMilliseconds);
+
                         var webSocket = await context.WebSockets.AcceptWebSocketAsync();
                         await SendResponse(webSocket,
                             ResponseMessage.TextMessage($"Hello, you are connected to '{nameof(SimpleStartup)}'"));

--- a/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
+++ b/test_integration/Websocket.Client.Tests.Integration/WebsocketClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Reactive.Linq;
 using System.Threading;
@@ -36,7 +37,7 @@ namespace Websocket.Client.Tests.Integration
 
             await client.Start();
 
-            receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
+            receivedEvent.WaitOne(TimeSpan.FromSeconds(Debugger.IsAttached ? 30 : 3));
 
             Assert.NotNull(received);
         }
@@ -72,7 +73,7 @@ namespace Websocket.Client.Tests.Integration
             client.Send("ping");
             client.Send("ping");
 
-            receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
+            receivedEvent.WaitOne(TimeSpan.FromSeconds(Debugger.IsAttached ? 30 : 3));
 
             Assert.NotNull(received);
         }
@@ -106,15 +107,15 @@ namespace Websocket.Client.Tests.Integration
             });
 
             await client.Start();
-            await Task.Delay(5000);
+            await Task.Delay(500);
             await client.Stop(WebSocketCloseStatus.Empty, string.Empty);
 
-            await Task.Delay(5000);
+            await Task.Delay(500);
 
             await client.Start();
-            await Task.Delay(1000);
+            await Task.Delay(100);
 
-            receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
+            receivedEvent.WaitOne(TimeSpan.FromSeconds(Debugger.IsAttached ? 30 : 3));
 
             Assert.Equal(2, receivedCount);
         }
@@ -126,7 +127,7 @@ namespace Websocket.Client.Tests.Integration
             var receivedCount = 0;
 
             client.IsReconnectionEnabled = true;
-            client.ReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.ReconnectTimeout = TimeSpan.FromMilliseconds(500);
 
             client.MessageReceived.Subscribe(msg =>
             {
@@ -136,7 +137,7 @@ namespace Websocket.Client.Tests.Integration
             });
 
             await client.Start();
-            await Task.Delay(17000);
+            await Task.Delay(3000);
 
             Assert.Equal(2, receivedCount);
         }
@@ -145,7 +146,7 @@ namespace Websocket.Client.Tests.Integration
         public async Task OnClose_ShouldWorkCorrectly()
         {
             using IWebsocketClient client = new WebsocketClient(_websocketUrl);
-            client.ReconnectTimeout = TimeSpan.FromSeconds(5);
+            client.ReconnectTimeout = TimeSpan.FromMilliseconds(500);
 
             string received = null;
             var receivedCount = 0;
@@ -169,13 +170,13 @@ namespace Websocket.Client.Tests.Integration
 
             _ = Task.Run(async () =>
             {
-                await Task.Delay(2000);
+                await Task.Delay(200);
                 var success = await client.Stop(WebSocketCloseStatus.InternalServerError, "server error 500");
                 Assert.True(success);
                 receivedEvent.Set();
             });
 
-            receivedEvent.WaitOne(TimeSpan.FromSeconds(30));
+            receivedEvent.WaitOne(TimeSpan.FromSeconds(Debugger.IsAttached ? 30 : 3));
 
             Assert.NotNull(received);
             Assert.Equal(1, receivedCount);
@@ -191,7 +192,7 @@ namespace Websocket.Client.Tests.Integration
             Assert.Equal("server error 500", nativeClient.CloseStatusDescription);
 
             // check that reconnection is disabled
-            await Task.Delay(7000);
+            await Task.Delay(2000);
             Assert.Equal(1, receivedCount);
         }
 


### PR DESCRIPTION
Fixes #156 

This PR fixes a few problems raised in the above issue:

- Wrong `ReconnectionType` after receiving `Close` message from server
- Duplicate events on `DisconnectionHappened` stream
- Sometimes hanging forever when trying to connect

I have split the changes into separate commits, for easier reviewing. I've also taken the opportunity to improve the tests, by making them faster and more debuggable. I've also added some public members for better diagnotics/debugging support.